### PR TITLE
ci: Add an env variable for the changesets step in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           publish: npx changeset publish
           


### PR DESCRIPTION
This PR sets up the NPM_TOKEN env variable for the changesets step in the release workflow